### PR TITLE
Remove breaking '.options' from calling assocations

### DIFF
--- a/app/templates/models/_index.js
+++ b/app/templates/models/_index.js
@@ -19,8 +19,8 @@ fs
   })
 
 Object.keys(db).forEach(function(modelName) {
-  if (db[modelName].options.hasOwnProperty('associate')) {
-    db[modelName].options.associate(db)
+  if (db[modelName].hasOwnProperty('associate')) {
+    db[modelName].associate(db)
   }
 })
 


### PR DESCRIPTION
Similar pull request:
https://github.com/rayokota/generator-angular-express-sequelize/pull/7

Stack overflow issue:
http://stackoverflow.com/questions/27664242/sequelize-eager-loading-association-with-through-table
